### PR TITLE
preserve scroll new tab, highlight active, earlier sticky hide

### DIFF
--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -12,6 +12,11 @@
 
 
   import {
+    activeBookmarkId,
+    clearActiveBookmarkId,
+    setActiveBookmarkId
+  } from "../lib/services/active-bookmark"
+  import {
     getActiveTradeTabTitle,
     openUrlInActiveTab,
     openUrlInNewTab,
@@ -489,6 +494,9 @@
   }
 
   const openTradeLive = async (trade: BookmarksTradeStruct) => {
+    if (trade.id) {
+      setActiveBookmarkId(trade.id)
+    }
     await openUrlInActiveTab(
       resolveTradeUrl(trade.location, "/live", true)
     )
@@ -500,6 +508,10 @@
     trades = trades.filter((entry) => entry.id !== trade.id)
     hasLoadedTrades = true
     tradePendingDelete = null
+
+    if (trade.id === $activeBookmarkId) {
+      clearActiveBookmarkId()
+    }
 
     void bookmarksService.deleteTrade(trade.id, folder.id)
       .then((persisted) => {
@@ -752,6 +764,9 @@
     trade: BookmarksTradeStruct,
     target: TradeOpenTarget = "active"
   ) => {
+    if (target === "active" && trade.id) {
+      setActiveBookmarkId(trade.id)
+    }
     const scrollTop = scrollContainer?.scrollTop
     if (target === "active" && scrollContainer) {
       await saveBookmarkScroll(scrollContainer.scrollTop)
@@ -762,7 +777,7 @@
     const url = resolveTradeUrl(trade.location, "", true)
     await (
       target === "tab"
-        ? openUrlInNewTab(url, false, undefined, scrollTop)
+        ? openUrlInNewTab(url, false, trade.id, scrollTop)
         : target === "window"
           ? openUrlInNewWindow(url)
           : openUrlInActiveTab(url)
@@ -1080,6 +1095,9 @@
   let folderIconUrl = $derived(getBookmarkFolderIconUrl(folder.icon))
   let folderEditIconUrl = $derived(getBookmarkFolderIconUrl(folderEditIcon))
 
+  const isCurrentTrade = (trade: BookmarksTradeStruct) =>
+    !!$activeBookmarkId && trade.id === $activeBookmarkId
+
   $effect(() => {
     if (previewTrades) {
       trades = previewTrades
@@ -1356,6 +1374,7 @@
               {@const trade = entry.trade}
               {@const i = entry.displayIndex}
               {@const tradeCategoryId = categoryIdForTrade(trade)}
+              {@const isActiveTrade = isCurrentTrade(trade)}
               <li
                 draggable="true"
                 ondragstart={(e) => handleDragStart(e, i)}
@@ -1392,9 +1411,11 @@
                   class="trade-item"
                   class:is-completed={!!trade.completedAt}
                   class:is-archived={!!trade.archivedAt}
+                  class:is-current={isActiveTrade}
                   class:is-dragging={draggedIndex === i}
                   class:is-drag-over={dragOverIndex === i}
                   role="group"
+                  aria-current={isActiveTrade ? "page" : undefined}
                   aria-label={trade.title}
                   onpointerdown={handleTradeCardPointerDown}
                   onpointerup={(event) => handleTradeCardClick(event, trade)}>
@@ -2041,6 +2062,18 @@
 .trade-item.is-completed {
   background: rgba(30, 77, 30, 0.14);
   border-color: rgba(30, 77, 30, 0.28);
+}
+.trade-item.is-current {
+  border-color: rgba(163, 141, 109, 0.42);
+  background: rgba(163, 141, 109, 0.12);
+}
+.trade-item.is-current.is-completed {
+  border-color: rgba(163, 141, 109, 0.36);
+  background: linear-gradient(
+    90deg,
+    rgba(30, 77, 30, 0.14),
+    rgba(163, 141, 109, 0.12)
+  );
 }
 .trade-item.is-drag-over {
   border-color: rgba(163, 141, 109, 0.42);

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -752,10 +752,9 @@
     trade: BookmarksTradeStruct,
     target: TradeOpenTarget = "active"
   ) => {
-    if (target === "active") {
-      if (scrollContainer) {
-        await saveBookmarkScroll(scrollContainer.scrollTop)
-      }
+    const scrollTop = scrollContainer?.scrollTop
+    if (target === "active" && scrollContainer) {
+      await saveBookmarkScroll(scrollContainer.scrollTop)
     }
     await tradeLocationService.stashPendingBookmarkTitles({
       [trade.location.slug]: trade.title
@@ -763,7 +762,7 @@
     const url = resolveTradeUrl(trade.location, "", true)
     await (
       target === "tab"
-        ? openUrlInNewTab(url)
+        ? openUrlInNewTab(url, false, undefined, scrollTop)
         : target === "window"
           ? openUrlInNewWindow(url)
           : openUrlInActiveTab(url)

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -1296,7 +1296,9 @@
                   void handleCategoryDrop(event, entry.category!.id)
                 } : undefined}
                 ondragend={entry.category ? handleCategoryDragEnd : undefined}>
-                <div class="category-heading">
+                <div
+                  class="category-heading"
+                  onclick={() => toggleCategoryCollapse(entry.categoryId)}>
                   {#if entry.category}
                     <button
                       type="button"
@@ -1314,7 +1316,6 @@
                     class="category-toggle"
                     aria-expanded={!isCategoryCollapsed(entry.categoryId)}
                     aria-label={`${isCategoryCollapsed(entry.categoryId) ? translate($languageStore, "folder.expand") : translate($languageStore, "folder.collapse")} ${entry.title}`}
-                    onclick={() => toggleCategoryCollapse(entry.categoryId)}
                   >
                     {isCategoryCollapsed(entry.categoryId) ? "▸" : "▾"}
                   </button>
@@ -1322,7 +1323,7 @@
                   <span
                     class="category-heading__title category-heading__drag-area"
                     role="button"
-                    aria-label={entry.title}
+                    aria-label={`${isCategoryCollapsed(entry.categoryId) ? translate($languageStore, "folder.expand") : translate($languageStore, "folder.collapse")} ${entry.title}`}
                     tabindex={entry.category ? 0 : -1}
                     draggable={!!entry.category}
                     ondragstart={entry.category
@@ -1332,7 +1333,9 @@
                   <span class="category-heading__count">{entry.tradeCount}</span>
                   <span class="category-heading__rule" aria-hidden="true"></span>
                   {#if entry.category}
-                    <div class="category-heading__actions">
+                    <div
+                      class="category-heading__actions"
+                      onclick={(event) => event.stopPropagation()}>
                       <ActionsMenu
                         actions={[
                           ...(categoryIndex > 0 ? [{
@@ -1942,6 +1945,7 @@
   min-height: 28px;
   padding: 2px 4px;
   color: rgba(196, 177, 140, 0.82);
+  cursor: pointer;
   font-family: "FontinSmallcaps", serif;
   font-size: calc(11px * var(--bt-text-scale, 1));
   font-weight: 700;

--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -14,6 +14,7 @@
   import {
     activeBookmarkId,
     clearActiveBookmarkId,
+    saveActiveBookmark,
     setActiveBookmarkId
   } from "../lib/services/active-bookmark"
   import {
@@ -496,6 +497,7 @@
   const openTradeLive = async (trade: BookmarksTradeStruct) => {
     if (trade.id) {
       setActiveBookmarkId(trade.id)
+      await saveActiveBookmark(trade.id)
     }
     await openUrlInActiveTab(
       resolveTradeUrl(trade.location, "/live", true)
@@ -766,6 +768,7 @@
   ) => {
     if (target === "active" && trade.id) {
       setActiveBookmarkId(trade.id)
+      await saveActiveBookmark(trade.id)
     }
     const scrollTop = scrollContainer?.scrollTop
     if (target === "active" && scrollContainer) {
@@ -1296,9 +1299,7 @@
                   void handleCategoryDrop(event, entry.category!.id)
                 } : undefined}
                 ondragend={entry.category ? handleCategoryDragEnd : undefined}>
-                <div
-                  class="category-heading"
-                  onclick={() => toggleCategoryCollapse(entry.categoryId)}>
+                <div class="category-heading">
                   {#if entry.category}
                     <button
                       type="button"
@@ -1316,26 +1317,25 @@
                     class="category-toggle"
                     aria-expanded={!isCategoryCollapsed(entry.categoryId)}
                     aria-label={`${isCategoryCollapsed(entry.categoryId) ? translate($languageStore, "folder.expand") : translate($languageStore, "folder.collapse")} ${entry.title}`}
+                    onclick={() => toggleCategoryCollapse(entry.categoryId)}
                   >
                     {isCategoryCollapsed(entry.categoryId) ? "▸" : "▾"}
                   </button>
                   <span class="category-heading__rule" aria-hidden="true"></span>
-                  <span
+                  <button
+                    type="button"
                     class="category-heading__title category-heading__drag-area"
-                    role="button"
                     aria-label={`${isCategoryCollapsed(entry.categoryId) ? translate($languageStore, "folder.expand") : translate($languageStore, "folder.collapse")} ${entry.title}`}
-                    tabindex={entry.category ? 0 : -1}
                     draggable={!!entry.category}
+                    onclick={() => toggleCategoryCollapse(entry.categoryId)}
                     ondragstart={entry.category
                       ? (event) => handleCategoryDragStart(event, entry.category!)
                       : undefined}
-                    ondragend={entry.category ? handleCategoryDragEnd : undefined}>{entry.title}</span>
+                    ondragend={entry.category ? handleCategoryDragEnd : undefined}>{entry.title}</button>
                   <span class="category-heading__count">{entry.tradeCount}</span>
                   <span class="category-heading__rule" aria-hidden="true"></span>
                   {#if entry.category}
-                    <div
-                      class="category-heading__actions"
-                      onclick={(event) => event.stopPropagation()}>
+                    <div class="category-heading__actions">
                       <ActionsMenu
                         actions={[
                           ...(categoryIndex > 0 ? [{
@@ -1988,6 +1988,14 @@
 
 .category-heading__title {
   max-width: 62%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-align: left;
+  text-transform: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/Layout.svelte
+++ b/components/Layout.svelte
@@ -19,6 +19,7 @@ import About from "./pages/About.svelte";
   import logoUrl from "~assets/logo.webp?inline";
   import { flashMessages } from "../lib/services/flash";
   import { bookmarksService } from "../lib/services/bookmarks";
+  import { hydrateActiveBookmarkFromTab } from "../lib/services/active-bookmark";
   import { languageStore, translate } from "../lib/services/i18n";
   import { DEFAULT_SIDEBAR_WIDTH, settings } from "../lib/services/settings";
   import { experimentalSettings } from "../lib/services/experimental";
@@ -192,6 +193,7 @@ import About from "./pages/About.svelte";
 
   onMount(async () => {
     await settings.load();
+    await hydrateActiveBookmarkFromTab();
     tradeLocationService.startPolling();
     const unsubscribeLocation = tradeLocationService.locationStore.subscribe((location) => {
       currentTradeVersion = location.version;

--- a/components/pages/Bookmarks.svelte
+++ b/components/pages/Bookmarks.svelte
@@ -73,6 +73,7 @@
   let toolbarRepairFrame = 0;
   let toolbarRepairTimeouts: number[] = [];
   let toolbarRepairAttempts = 0;
+  let isAtBookmarkTop = $state(true);
 
 
   const normalizeExpandedFolderIds = (value: unknown): string[] => {
@@ -327,6 +328,10 @@
     active: archiveRestoreIcon
   };
 
+  const syncBookmarkTop = () => {
+    isAtBookmarkTop = !scrollContainer || scrollContainer.scrollTop <= 0;
+  };
+
   const restoreBookmarkScroll = async () => {
     if (!scrollContainer) return true;
 
@@ -334,6 +339,7 @@
     if (top === null) return true;
 
     scrollContainer.scrollTop = top;
+    syncBookmarkTop();
     const canReachSavedPosition =
       scrollContainer.scrollHeight - scrollContainer.clientHeight >= top;
     if (canReachSavedPosition) await clearBookmarkScroll();
@@ -353,6 +359,10 @@
   };
 
   const isToolbarVisible = () => {
+    if (!isAtBookmarkTop) {
+      return true;
+    }
+
     if (!toolbarStickyEl || !toolbarStickyEl.isConnected) {
       return false;
     }
@@ -366,7 +376,7 @@
       toolbarRepairFrame = 0;
       await tick();
 
-      if (isToolbarVisible()) {
+      if (!isAtBookmarkTop || isToolbarVisible()) {
         toolbarRepairAttempts = 0;
         return;
       }
@@ -478,11 +488,33 @@
       observer.disconnect();
     };
   });
+
+  $effect(() => {
+    const el = scrollContainer;
+    if (!el) {
+      isAtBookmarkTop = true;
+      return;
+    }
+
+    const onScroll = () => {
+      isAtBookmarkTop = el.scrollTop <= 0;
+    };
+
+    onScroll();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  });
 </script>
 
 <div class="bookmarks-page" data-tutorial="bookmarks-panel">
   {#key toolbarRenderKey}
-    <div class="toolbar-sticky" data-tutorial="bookmarks-toolbar" bind:this={toolbarStickyEl}>
+    <div
+      class="toolbar-sticky"
+      class:is-hidden={!isAtBookmarkTop}
+      data-tutorial="bookmarks-toolbar"
+      bind:this={toolbarStickyEl}
+      aria-hidden={!isAtBookmarkTop}
+    >
       <section class="toolbar-panel">
         <div class="toolbar-row">
           <div class="toolbar-actions toolbar-actions--primary">
@@ -628,14 +660,15 @@
 }
 
 .toolbar-sticky {
-  position: sticky;
-  top: 0;
-  z-index: 3;
   flex: 0 0 auto;
   min-width: 0;
   isolation: isolate;
   transform: translateZ(0);
   backface-visibility: hidden;
+}
+
+.toolbar-sticky.is-hidden {
+  display: none;
 }
 
 .toolbar-panel {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
   bookmarkScrollMessage,
   getBookmarkScrollRestoreKey
 } from "~/lib/services/bookmark-scroll"
+import { tabsCreateMessage } from "~/lib/services/active-trade-tab"
 
 const getStorageUsage = async () => {
   const measure = async (
@@ -212,10 +213,45 @@ export default defineBackground({
         return false
       }
 
+      if (request?.type === tabsCreateMessage.create) {
+        const url = request.url
+        const active = request.active === true
+        const scrollTop =
+          typeof request.scrollTop === "number" &&
+          Number.isFinite(request.scrollTop) &&
+          request.scrollTop >= 0
+            ? request.scrollTop
+            : null
+        if (typeof url !== "string" || !url) {
+          sendResponse({ ok: false })
+          return false
+        }
+
+        chrome.tabs
+          .create({ url, active })
+          .then(async (tab) => {
+            if (scrollTop !== null && typeof tab.id === "number") {
+              await storageService.setValue(getBookmarkScrollRestoreKey(tab.id), {
+                top: scrollTop,
+                savedAt: Date.now()
+              })
+            }
+            sendResponse({ ok: true })
+          })
+          .catch(() => sendResponse({ ok: false }))
+        return true
+      }
+
       if (request?.type === bookmarkScrollMessage.save) {
         const value = request.value
+        const targetTabId =
+          typeof request.tabId === "number" ? request.tabId : sender.tab?.id
+        const targetScrollKey =
+          typeof targetTabId === "number"
+            ? getBookmarkScrollRestoreKey(targetTabId)
+            : null
         if (
-          !bookmarkScrollKey ||
+          !targetScrollKey ||
           typeof value?.top !== "number" ||
           !Number.isFinite(value.top) ||
           value.top < 0 ||
@@ -226,7 +262,7 @@ export default defineBackground({
         }
 
         storageService
-          .setValue(bookmarkScrollKey, { top: value.top, savedAt: value.savedAt })
+          .setValue(targetScrollKey, { top: value.top, savedAt: value.savedAt })
           .then((ok) => sendResponse({ ok }))
           .catch(() => sendResponse({ ok: false }))
         return true

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,11 @@ import {
   bookmarkScrollMessage,
   getBookmarkScrollRestoreKey
 } from "~/lib/services/bookmark-scroll"
+import {
+  ACTIVE_BOOKMARK_RESTORE_MAX_AGE_MS,
+  activeBookmarkMessage,
+  getActiveBookmarkTabKey
+} from "~/lib/services/active-bookmark"
 import { tabsCreateMessage } from "~/lib/services/active-trade-tab"
 
 const getStorageUsage = async () => {
@@ -216,6 +221,8 @@ export default defineBackground({
       if (request?.type === tabsCreateMessage.create) {
         const url = request.url
         const active = request.active === true
+        const bookmarkId =
+          typeof request.bookmarkId === "string" ? request.bookmarkId : ""
         const scrollTop =
           typeof request.scrollTop === "number" &&
           Number.isFinite(request.scrollTop) &&
@@ -230,15 +237,76 @@ export default defineBackground({
         chrome.tabs
           .create({ url, active })
           .then(async (tab) => {
-            if (scrollTop !== null && typeof tab.id === "number") {
-              await storageService.setValue(getBookmarkScrollRestoreKey(tab.id), {
-                top: scrollTop,
-                savedAt: Date.now()
-              })
+            if (typeof tab.id === "number") {
+              if (bookmarkId) {
+                await storageService.setValue(getActiveBookmarkTabKey(tab.id), {
+                  id: bookmarkId,
+                  savedAt: Date.now()
+                })
+              }
+              if (scrollTop !== null) {
+                await storageService.setValue(getBookmarkScrollRestoreKey(tab.id), {
+                  top: scrollTop,
+                  savedAt: Date.now()
+                })
+              }
             }
             sendResponse({ ok: true })
           })
           .catch(() => sendResponse({ ok: false }))
+        return true
+      }
+
+      if (request?.type === activeBookmarkMessage.save) {
+        const activeTabId =
+          typeof request.tabId === "number" ? request.tabId : sender.tab?.id
+        const value = request.value
+        if (
+          typeof activeTabId !== "number" ||
+          typeof value?.id !== "string" ||
+          !value.id ||
+          typeof value.savedAt !== "number"
+        ) {
+          sendResponse({ ok: false })
+          return false
+        }
+
+        storageService
+          .setValue(getActiveBookmarkTabKey(activeTabId), {
+            id: value.id,
+            savedAt: value.savedAt
+          })
+          .then((ok) => sendResponse({ ok }))
+          .catch(() => sendResponse({ ok: false }))
+        return true
+      }
+
+      if (request?.type === activeBookmarkMessage.consume) {
+        const activeBookmarkKey =
+          typeof tabId === "number" ? getActiveBookmarkTabKey(tabId) : null
+        if (!activeBookmarkKey) {
+          sendResponse({ id: null })
+          return false
+        }
+
+        storageService
+          .getValue<{ id: string; savedAt: number }>(activeBookmarkKey)
+          .then(async (saved) => {
+            if (
+              !saved ||
+              typeof saved.id !== "string" ||
+              !saved.id ||
+              typeof saved.savedAt !== "number" ||
+              Date.now() - saved.savedAt > ACTIVE_BOOKMARK_RESTORE_MAX_AGE_MS
+            ) {
+              if (saved) await storageService.deleteValue(activeBookmarkKey)
+              sendResponse({ id: null })
+              return
+            }
+            await storageService.deleteValue(activeBookmarkKey)
+            sendResponse({ id: saved.id })
+          })
+          .catch(() => sendResponse({ id: null }))
         return true
       }
 

--- a/lib/services/active-bookmark.ts
+++ b/lib/services/active-bookmark.ts
@@ -81,6 +81,15 @@ export const clearActiveBookmarkId = () => {
   setActiveBookmarkId(null)
 }
 
+export const saveActiveBookmark = async (id: string) => {
+  if (!id) return
+
+  await sendMessage({
+    type: activeBookmarkMessage.save,
+    value: { id, savedAt: Date.now() } satisfies ActiveBookmarkRestore
+  })
+}
+
 export const saveActiveBookmarkForTab = async (tabId: number, id: string) => {
   if (!Number.isInteger(tabId) || tabId < 0 || !id) return
 

--- a/lib/services/active-bookmark.ts
+++ b/lib/services/active-bookmark.ts
@@ -1,0 +1,107 @@
+﻿import { writable } from "svelte/store"
+import {
+  hasValidExtensionContext,
+  isExtensionContextInvalidatedError
+} from "../utilities/extension-context"
+
+const ACTIVE_BOOKMARK_ID_KEY = "poeTradePlus.activeBookmarkId"
+const ACTIVE_BOOKMARK_TAB_KEY_PREFIX = "active-bookmark--"
+export const ACTIVE_BOOKMARK_RESTORE_MAX_AGE_MS = 30_000
+
+export const activeBookmarkMessage = {
+  save: "poeTradePlus.activeBookmark.save",
+  consume: "poeTradePlus.activeBookmark.consume"
+} as const
+
+type ActiveBookmarkRestore = {
+  id: string
+  savedAt: number
+}
+
+export const getActiveBookmarkTabKey = (tabId: number) =>
+  `${ACTIVE_BOOKMARK_TAB_KEY_PREFIX}${tabId}`
+
+const sendMessage = <T>(message: unknown): Promise<T | null> =>
+  new Promise((resolve) => {
+    if (!hasValidExtensionContext() || !chrome.runtime?.sendMessage) {
+      resolve(null)
+      return
+    }
+
+    try {
+      chrome.runtime.sendMessage(message, (response) => {
+        if (chrome.runtime.lastError) {
+          resolve(null)
+          return
+        }
+        resolve((response ?? null) as T | null)
+      })
+    } catch (error) {
+      if (!isExtensionContextInvalidatedError(error)) {
+        console.warn("[Poe Trade Plus] Failed to restore active bookmark", error)
+      }
+      resolve(null)
+    }
+  })
+
+const readStoredId = (): string | null => {
+  if (typeof sessionStorage === "undefined") return null
+
+  try {
+    const value = sessionStorage.getItem(ACTIVE_BOOKMARK_ID_KEY)
+    return value || null
+  } catch {
+    return null
+  }
+}
+
+const writeStoredId = (id: string | null) => {
+  if (typeof sessionStorage === "undefined") return
+
+  try {
+    if (id) {
+      sessionStorage.setItem(ACTIVE_BOOKMARK_ID_KEY, id)
+    } else {
+      sessionStorage.removeItem(ACTIVE_BOOKMARK_ID_KEY)
+    }
+  } catch {
+    // Ignore quota / access errors; the in-memory store still updates.
+  }
+}
+
+const { subscribe, set } = writable<string | null>(readStoredId())
+
+export const setActiveBookmarkId = (id: string | null | undefined) => {
+  const nextId = id || null
+  writeStoredId(nextId)
+  set(nextId)
+}
+
+export const clearActiveBookmarkId = () => {
+  setActiveBookmarkId(null)
+}
+
+export const saveActiveBookmarkForTab = async (tabId: number, id: string) => {
+  if (!Number.isInteger(tabId) || tabId < 0 || !id) return
+
+  await sendMessage({
+    type: activeBookmarkMessage.save,
+    tabId,
+    value: { id, savedAt: Date.now() } satisfies ActiveBookmarkRestore
+  })
+}
+
+export const hydrateActiveBookmarkFromTab = async () => {
+  if (readStoredId()) return
+
+  const response = await sendMessage<{ id?: unknown }>({
+    type: activeBookmarkMessage.consume
+  })
+  if (typeof response?.id === "string" && response.id) {
+    setActiveBookmarkId(response.id)
+  }
+}
+
+export const activeBookmarkId = {
+  subscribe
+}

--- a/lib/services/active-trade-tab.ts
+++ b/lib/services/active-trade-tab.ts
@@ -2,6 +2,7 @@ import {
   hasValidExtensionContext,
   isExtensionContextInvalidatedError
 } from "../utilities/extension-context"
+import { saveActiveBookmarkForTab } from "./active-bookmark"
 import { saveBookmarkScrollForTab } from "./bookmark-scroll"
 
 const TRADE_URL_PATTERN =
@@ -119,8 +120,13 @@ export const openUrlInNewTab = async (
   if (hasValidExtensionContext() && chrome.tabs?.create) {
     try {
       const tab = await chrome.tabs.create({ url, active })
-      if (typeof tab.id === "number" && typeof scrollTop === "number") {
-        await saveBookmarkScrollForTab(tab.id, scrollTop)
+      if (typeof tab.id === "number") {
+        if (bookmarkId) {
+          await saveActiveBookmarkForTab(tab.id, bookmarkId)
+        }
+        if (typeof scrollTop === "number") {
+          await saveBookmarkScrollForTab(tab.id, scrollTop)
+        }
       }
       return
     } catch (error) {

--- a/lib/services/active-trade-tab.ts
+++ b/lib/services/active-trade-tab.ts
@@ -2,9 +2,14 @@ import {
   hasValidExtensionContext,
   isExtensionContextInvalidatedError
 } from "../utilities/extension-context"
+import { saveBookmarkScrollForTab } from "./bookmark-scroll"
 
 const TRADE_URL_PATTERN =
   /^https:\/\/(?:(?:[^./]+\.)?pathofexile\.com|pathofexile\.tw|poe(?:2)?\.kakaogames\.com)\/trade(?:2)?(?:\/|$)/i
+
+export const tabsCreateMessage = {
+  create: "poeTradePlus.tabs.create"
+} as const
 
 const getActiveTab = async () => {
   if (!hasValidExtensionContext() || !chrome.tabs?.query) {
@@ -71,18 +76,62 @@ export const openUrlInActiveTab = async (url: string) => {
   }
 }
 
-export const openUrlInNewTab = async (url: string) => {
-  // Open inactive so repeated middle-clicks can queue searches without taking
-  // focus away from the bookmark panel or the current trade search.
+const requestTabCreate = (
+  url: string,
+  active: boolean,
+  bookmarkId?: string,
+  scrollTop?: number
+): Promise<boolean> =>
+  new Promise((resolve) => {
+    if (!hasValidExtensionContext() || !chrome.runtime?.sendMessage) {
+      resolve(false)
+      return
+    }
+
+    try {
+      chrome.runtime.sendMessage(
+        { type: tabsCreateMessage.create, url, active, bookmarkId, scrollTop },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            resolve(false)
+            return
+          }
+          resolve(!!response?.ok)
+        }
+      )
+    } catch (error) {
+      if (!isExtensionContextInvalidatedError(error)) {
+        console.warn("[Poe Trade Plus] Failed to request a new tab", error)
+      }
+      resolve(false)
+    }
+  })
+
+export const openUrlInNewTab = async (
+  url: string,
+  active = false,
+  bookmarkId?: string,
+  scrollTop?: number
+) => {
+  // Prefer chrome.tabs when available (popup / background). Content scripts
+  // lack tabs API access, so they ask the background to create the tab with
+  // the requested focus so middle-click can stay in the background.
   if (hasValidExtensionContext() && chrome.tabs?.create) {
     try {
-      await chrome.tabs.create({ url, active: false })
+      const tab = await chrome.tabs.create({ url, active })
+      if (typeof tab.id === "number" && typeof scrollTop === "number") {
+        await saveBookmarkScrollForTab(tab.id, scrollTop)
+      }
       return
     } catch (error) {
       if (!isExtensionContextInvalidatedError(error)) {
         console.warn("[Poe Trade Plus] Failed to open a new tab", error)
       }
     }
+  }
+
+  if (await requestTabCreate(url, active, bookmarkId, scrollTop)) {
+    return
   }
 
   if (typeof window !== "undefined") {

--- a/lib/services/bookmark-scroll.ts
+++ b/lib/services/bookmark-scroll.ts
@@ -52,6 +52,18 @@ export const saveBookmarkScroll = async (top: number) => {
   })
 }
 
+export const saveBookmarkScrollForTab = async (tabId: number, top: number) => {
+  if (!Number.isInteger(tabId) || tabId < 0 || !Number.isFinite(top) || top < 0) {
+    return
+  }
+
+  await sendMessage({
+    type: bookmarkScrollMessage.save,
+    tabId,
+    value: { top, savedAt: Date.now() } satisfies BookmarkScrollRestore
+  })
+}
+
 export const consumeBookmarkScroll = async (): Promise<number | null> => {
   const response = await sendMessage<{ top?: unknown }>({
     type: bookmarkScrollMessage.consume


### PR DESCRIPTION
Summary
Improves bookmark sidebar when browsing, editing, and jumping between trade tabs.

The sticky toolbar only hides after scrolling down roughly one page, so controls stay reachable longer during normal browsing. Active-bookmark highlight makes it easier to spot the current trade when updating, replacing, or switching back and forth between tabs. Opening a bookmark in a new tab now preserves the sidebar scroll position, so you return to the same place in the list. Category rows can be collapsed or expanded by clicking anywhere on the heading, not only the ▸/▾ icon.

Main changes
Save bookmark scroll on new-tab open.
Track and highlight the active bookmark by bookmarkId across tabs.
Adjust sticky hide threshold so it disappears earlier / after ~one page of scroll.
Wire category collapse to the full .category-heading click target.