### PR TITLE
feat(bookmark): preserve scroll on replace and inline-edit new trade name

### DIFF
--- a/components/BookmarkFolder.svelte
+++ b/components/BookmarkFolder.svelte
@@ -23,7 +23,10 @@
     openUrlInNewTab,
     openUrlInNewWindow
   } from "../lib/services/active-trade-tab"
-  import { saveBookmarkScroll } from "../lib/services/bookmark-scroll"
+  import {
+    consumeBookmarkScroll,
+    saveBookmarkScroll
+  } from "../lib/services/bookmark-scroll"
   import { bookmarksService } from "../lib/services/bookmarks"
   import {
     bookmarkFolderIconOptions,
@@ -165,8 +168,20 @@
   }
 
   const refreshTrades = async () => {
+    const top = scrollContainer?.scrollTop
+    if (typeof top === "number") {
+      await saveBookmarkScroll(top)
+    }
     hasLoadedTrades = false
     await loadTrades(true)
+    await tick()
+    // `consumeBookmarkScroll` is fire-once: if a second refresh started before
+    // we consumed, the latest save wins and our local `top` becomes the
+    // fallback if the consume returns null.
+    const savedTop = (await consumeBookmarkScroll()) ?? top
+    if (scrollContainer && typeof savedTop === "number") {
+      scrollContainer.scrollTop = savedTop
+    }
   }
 
   const syncTradesFromCache = () => {
@@ -740,6 +755,11 @@
 
   const createTradeFromCurrent = async () => {
     if (!folder.id) return
+    if (draftTrade) {
+      tradeEditInputEl?.focus()
+      tradeEditInputEl?.select()
+      return
+    }
     const current = tradeLocationService.current
     if (!current.slug) {
       flashMessages.alert(translate($languageStore, "folder.invalidTradePage"))
@@ -762,11 +782,14 @@
         .replace(" - Path of Exile", "")
         .replace(/⚡ /g, "") ||
       translate($languageStore, "folder.tradeFallback")
-    await bookmarksService.persistTrade(trade, folder.id)
-    await refreshTrades()
-    flashMessages.success(
-      translate($languageStore, "folder.addedToFolder", { title: trade.title })
-    )
+
+    editingTradeId = null
+    draftTrade = trade
+    tradeEditTitle = trade.title
+
+    await tick()
+    tradeEditInputEl?.focus()
+    tradeEditInputEl?.select()
   }
 
   type TradeOpenTarget = "active" | "tab" | "window"
@@ -950,9 +973,12 @@
   let tradeEditTitle = $state("")
   let tradeEditInputEl: HTMLInputElement | null = $state(null)
   let savingTradeId: string | null = null
+  let draftTrade: BookmarksTradeStruct | null = $state(null)
+  let isCommittingDraft = false
 
   const startEditingTrade = async (trade: BookmarksTradeStruct) => {
     if (!trade.id) return
+    draftTrade = null
     editingTradeId = trade.id
     tradeEditTitle = trade.title
     await tick()
@@ -980,6 +1006,44 @@
 
   const cancelTradeEdit = () => {
     editingTradeId = null
+  }
+
+  const cancelDraftTrade = () => {
+    draftTrade = null
+  }
+
+  // Blur keeps the draft when the user typed a title; otherwise it cancels
+  // silently. This avoids losing typed input when the user clicks away from
+  // the input by accident.
+  const handleDraftBlur = () => {
+    if (tradeEditTitle.trim().length > 0) {
+      void commitDraftTrade()
+    } else {
+      cancelDraftTrade()
+    }
+  }
+
+  const commitDraftTrade = async () => {
+    if (!draftTrade || !folder.id || isCommittingDraft) return
+    const pendingTrade = draftTrade
+    const title = tradeEditTitle.trim() || pendingTrade.title
+
+    isCommittingDraft = true
+    try {
+      // `persistTrade` only appends when the trade has no id, so the draft must
+      // stay id-less until the service assigns one.
+      await bookmarksService.persistTrade(
+        { ...pendingTrade, id: undefined, title },
+        folder.id
+      )
+      cancelDraftTrade()
+      await refreshTrades()
+      flashMessages.success(
+        translate($languageStore, "folder.addedToFolder", { title })
+      )
+    } finally {
+      isCommittingDraft = false
+    }
   }
 
   const openTradeFromCard = (
@@ -1065,6 +1129,7 @@
       trades = []
       hasLoadedTrades = false
       isLoading = false
+      cancelDraftTrade()
     }
   });
   $effect(() => {
@@ -1516,6 +1581,28 @@
               </li>
             {/if}
           {/each}
+          {#if draftTrade}
+            <li>
+              <div class="trade-item">
+                <div class="trade-content">
+                  <div class="trade-top">
+                    <input
+                      type="text"
+                      class="inline-edit-input trade-edit"
+                      aria-label={translate($languageStore, "folder.saveCurrentSearch")}
+                      bind:this={tradeEditInputEl}
+                      bind:value={tradeEditTitle}
+                      onblur={handleDraftBlur}
+                      onkeydown={(event) => {
+                        event.stopPropagation()
+                        if (event.key === "Enter") void commitDraftTrade()
+                        if (event.key === "Escape") cancelDraftTrade()
+                      }} />
+                  </div>
+                </div>
+              </div>
+            </li>
+          {/if}
         </ul>
         {#if !previewTrades}
           <div class="footer-actions">


### PR DESCRIPTION
Supersedes #12.

## Why a new PR
#12 was opened against the pre-F1-F10 main and would have collided with the refactor that landed on main. This branch rebases the same intent on the refactored main, addresses the review notes, and supersedes #12.

## What it does
- **Scroll preservation on replace** — refreshTrades saves the current scrollTop via saveBookmarkScroll before refetching and restores it (via consumeBookmarkScroll) after a tick so the DOM is ready.
- **Inline-edit new trade name** — createTradeFromCurrent no longer persists immediately. It stages a draft so the user can name the bookmark before saving. Enter commits, Escape cancels, blur keeps the draft when a title is typed and discards it when empty (so accidental clicks do not lose work).
- **Race-condition safety** — refreshTrades falls back to the locally captured scrollTop if the consume returns null (e.g. a second refresh overwrote the saved value). A comment in the code documents the contract.

## Diff vs #12
- Same core behaviour, but the draft input onblur now commits when the title is non-empty instead of silently cancelling the user's typed work.

## Verification
- pnpm typecheck clean.
- pnpm test 73/73 green.
- Manual smoke: scroll, click Replace, scroll position preserved; type a name in the new-trade input, click away, the typed name is kept.

## Out of scope
- Unit/E2E tests for the new behaviour were not added in this PR. The original #12 also lacked them; happy to follow up with a separate test PR if wanted.